### PR TITLE
Filter sidebar categories by city

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,6 +10,9 @@
 <aside class="sidebar sidebar--{{ sidebar_variant }}" id="sidebar" aria-label="Sidebar">
   <a class="brand side-brand" href="/">Things To Do With Kids</a>
   {% if city_slug %}
+    {% assign city_activities = site.activities | where: 'city', city_slug %}
+    {% assign city_categories = city_activities | map: 'categories' | join: ',' %}
+    {% assign present_categories = city_categories | split: ',' | uniq %}
     <div class="city-select">
       <button class="city-select-toggle" aria-controls="city-menu" aria-expanded="false">{{ current_city.city_title | default: current_city.title | default: city_slug | replace: "-", " " | capitalize }}</button>
       <ul id="city-menu" class="city-menu" hidden>
@@ -21,7 +24,14 @@
     <h2 class="side-title">Categories</h2>
     <ul class="pill-list">
       {% for c in categories %}
-        <li><a href="/{{ city_slug }}/{{ c | slugify }}/">{{ c | replace: "-", " " | capitalize }}</a></li>
+        {% assign category_slug = c | slugify %}
+        {% if category_slug != '' and present_categories contains category_slug %}
+          {% assign is_active_category = page.category == category_slug %}
+          <li>
+            <a class="pill-list__link{% if is_active_category %} is-active{% endif %}"
+               href="/{{ city_slug }}/{{ category_slug }}/"{% if is_active_category %} aria-current="page"{% endif %}>{{ c | replace: "-", " " | capitalize }}</a>
+          </li>
+        {% endif %}
       {% endfor %}
     </ul>
   {% else %}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5,6 +5,8 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-h
 .pill-list{display:flex;flex-wrap:wrap;gap:8px;list-style:none;padding:0;margin:0 0 16px}
 .pill-list a{border:1px solid #ddd;border-radius:999px;padding:6px 10px;text-decoration:none}
 .pill-list a:hover{text-decoration:underline}
+.pill-list__link.is-active{background:#4031a0;color:#fff;border-color:#4031a0;font-weight:600}
+.pill-list__link.is-active:hover{text-decoration:none}
 
 /* Layout shell paddings and window */
 .site-shell{padding:5px}


### PR DESCRIPTION
## Summary
- derive the category list for a city from its activities before rendering the sidebar
- highlight the active category pill for the current filter

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def2e605c0832c9025e808b40dc9cd