### PR TITLE
Generate city/category pages only where activities exist

### DIFF
--- a/category_pages/sydney/animals.md
+++ b/category_pages/sydney/animals.md
@@ -1,0 +1,10 @@
+---
+layout: city_category
+title: Animals things to do with kids in Sydney
+permalink: /sydney/animals/
+city_slug: sydney
+city_title: Sydney
+preposition: in
+category: animals
+h1: Animals things to do with kids in Sydney
+---

--- a/category_pages/sydney/indoor.md
+++ b/category_pages/sydney/indoor.md
@@ -1,0 +1,10 @@
+---
+layout: city_category
+title: Indoor things to do with kids in Sydney
+permalink: /sydney/indoor/
+city_slug: sydney
+city_title: Sydney
+preposition: in
+category: indoor
+h1: Indoor things to do with kids in Sydney
+---

--- a/category_pages/sydney/museums.md
+++ b/category_pages/sydney/museums.md
@@ -1,0 +1,10 @@
+---
+layout: city_category
+title: Museums things to do with kids in Sydney
+permalink: /sydney/museums/
+city_slug: sydney
+city_title: Sydney
+preposition: in
+category: museums
+h1: Museums things to do with kids in Sydney
+---

--- a/category_pages/sydney/outdoor.md
+++ b/category_pages/sydney/outdoor.md
@@ -1,0 +1,10 @@
+---
+layout: city_category
+title: Outdoor things to do with kids in Sydney
+permalink: /sydney/outdoor/
+city_slug: sydney
+city_title: Sydney
+preposition: in
+category: outdoor
+h1: Outdoor things to do with kids in Sydney
+---

--- a/scripts/gen_city_category_pages.py
+++ b/scripts/gen_city_category_pages.py
@@ -1,9 +1,10 @@
-import os, re, pathlib
+import re, pathlib
 
 ROOT = pathlib.Path(".")
 CITIES_DIR = ROOT / "_cities"
 CATS_FILE = ROOT / "_data" / "categories.yml"
 OUT_DIR = ROOT / "category_pages"
+ACTIVITIES_DIR = ROOT / "_activities"
 
 def slugify(s):
     s = (s or "").strip().lower()
@@ -19,6 +20,52 @@ def read_categories(path):
             m = re.match(r"^\s*-\s*(.+?)\s*$", line)
             if m: data.append(slugify(m.group(1)))
     return data
+
+def read_activity_city_categories(path):
+    city_cats = {}
+    if not path.exists():
+        return city_cats
+    for fp in path.glob("*.md"):
+        text = fp.read_text(encoding="utf-8")
+        m = re.search(r"^---\s*(.*?)\s*---", text, re.S | re.M)
+        if not m:
+            continue
+        fm = m.group(1)
+        city = None
+        categories = []
+        collecting_categories = False
+        for line in fm.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                if collecting_categories:
+                    break
+                continue
+            if stripped.startswith("city:"):
+                city = slugify(stripped.split(":", 1)[1])
+                collecting_categories = False
+                continue
+            if stripped.startswith("categories:"):
+                raw = stripped.split(":", 1)[1].strip()
+                if raw.startswith("[") and raw.endswith("]"):
+                    raw = raw[1:-1]
+                if raw:
+                    categories = [slugify(part) for part in raw.split(",") if part.strip()]
+                    collecting_categories = False
+                else:
+                    categories = []
+                    collecting_categories = True
+                continue
+            if collecting_categories:
+                if stripped.startswith("-"):
+                    item = stripped.lstrip("-").strip()
+                    if item:
+                        categories.append(slugify(item))
+                elif re.match(r"^[\w-]+:", stripped):
+                    collecting_categories = False
+                continue
+        if city and categories:
+            city_cats.setdefault(city, set()).update(categories)
+    return city_cats
 
 def read_city_meta(fp):
     meta = {"slug":"", "title":"", "city_title":"", "preposition":"in"}
@@ -38,12 +85,19 @@ def cat_display(c): return c.replace("-", " ").title()
 def main():
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     cats = read_categories(CATS_FILE)
+    city_categories = read_activity_city_categories(ACTIVITIES_DIR)
+    desired = set()
     for cf in sorted(CITIES_DIR.glob("*.md")):
         city = read_city_meta(cf)
+        city_slug = city["slug"]
+        city_title = city["city_title"]
+        prep = city.get("preposition","in")
+        allowed_categories = city_categories.get(city_slug, set())
+        if not allowed_categories:
+            continue
         for c in cats:
-            city_slug = city["slug"]
-            city_title = city["city_title"]
-            prep = city.get("preposition","in")
+            if c not in allowed_categories:
+                continue
             h1 = f"{cat_display(c)} things to do with kids {prep} {city_title}"
             title = h1
             out_dir = OUT_DIR / city_slug
@@ -62,8 +116,32 @@ def main():
                 "---",
                 ""
             ]
-            out.write_text("\n".join(fm), encoding="utf-8")
-            print("Wrote", out)
+            content = "\n".join(fm)
+            if out.exists() and out.read_text(encoding="utf-8") == content:
+                print("Unchanged", out)
+            else:
+                out.write_text(content, encoding="utf-8")
+                print("Wrote", out)
+            desired.add((city_slug, c))
+
+    prune_unused(desired)
+
+def prune_unused(desired):
+    if not OUT_DIR.exists():
+        return
+    for city_dir in list(OUT_DIR.iterdir()):
+        if not city_dir.is_dir():
+            continue
+        for md in list(city_dir.glob("*.md")):
+            combo = (city_dir.name, md.stem)
+            if combo not in desired:
+                md.unlink()
+                print("Removed", md)
+        if not any(city_dir.iterdir()):
+            city_dir.rmdir()
+            print("Removed empty directory", city_dir)
+    if not any(OUT_DIR.iterdir()):
+        OUT_DIR.rmdir()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- parse activity front matter to map each city to its available categories
- write city/category pages only when activities exist and prune empty outputs

## Testing
- python scripts/gen_city_category_pages.py

------
https://chatgpt.com/codex/tasks/task_e_68def2ea36a0832c8f52b414c874324a