### PR TITLE
Fix activity city links to avoid double slashes

### DIFF
--- a/_layouts/activity.html
+++ b/_layouts/activity.html
@@ -3,7 +3,7 @@ layout: default
 sidebar: city
 ---
 <article class="activity">
-  <p class="meta">In <a href="/{{ page.city | append: "/" | relative_url }}">{{ page.city | replace: '-', ' ' | capitalize }}</a>{% if page.categories %} · {{ page.categories | join: ", " }}{% endif %}</p>
+  <p class="meta">In <a href="{{ page.city | append: "/" | relative_url }}">{{ page.city | replace: '-', ' ' | capitalize }}</a>{% if page.categories %} · {{ page.categories | join: ", " }}{% endif %}</p>
   {{ content }}
 </article>
 


### PR DESCRIPTION
## Summary
- update the activity layout to let Jekyll generate city links without adding an extra leading slash

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df392ba3b4832cb97ea0a66ee6d1aa